### PR TITLE
Show latest cooking week with cooks

### DIFF
--- a/pages/cooking/cooks/[id].tsx
+++ b/pages/cooking/cooks/[id].tsx
@@ -68,6 +68,12 @@ export default function CookDetail() {
     fetchCook();
   }, [id]);
 
+  useEffect(() => {
+    if (router.query.edit) {
+      setIsEditing(true);
+    }
+  }, [router.query.edit]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);


### PR DESCRIPTION
from openai codex

## Summary
- fetch cooking weeks on homepage and show most recent week by default
- list cooks for the selected week with quick links to view or record
- allow cook detail page to open directly in edit mode via query param

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc9759c7a88324887f58186154c2d4